### PR TITLE
Don't include global prorotypes if the "prototypes" option is set to "inline"

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,10 +5,12 @@ module.exports = function(source) {
   this.cacheable && this.cacheable(true);
 
   var query = loaderUtils.parseQuery(this.query);
-  var tree = [
-    "require('nativejsx/dist/nativejsx-prototypes.js');",
-    nativejsx.transpile(source, query)
-  ];
+  var tree = [];
+
+  if (query && (query.prototypes !== 'inline')) {
+    tree.push("require('nativejsx/dist/nativejsx-prototypes.js');");
+  }
+  tree.push(nativejsx.transpile(source, query));
 
   return tree.join('\n');
 };

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = function(source) {
   var query = loaderUtils.parseQuery(this.query);
   var tree = [];
 
-  if (query && (query.prototypes !== 'inline')) {
+  if (query && (query.prototypes !== 'inline') && (query.prototypes !== 'module')) {
     tree.push("require('nativejsx/dist/nativejsx-prototypes.js');");
   }
   tree.push(nativejsx.transpile(source, query));


### PR DESCRIPTION
Fix for https://github.com/treycordova/nativejsx-loader/issues/5