### PR TITLE
Update loader-utils

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,13 +4,13 @@ var nativejsx = require('nativejsx');
 module.exports = function(source) {
   this.cacheable && this.cacheable(true);
 
-  var query = loaderUtils.parseQuery(this.query);
+  var options = loaderUtils.getOptions(this);
   var tree = [];
 
-  if (query && (query.prototypes !== 'inline') && (query.prototypes !== 'module')) {
+  if (options && (options.prototypes !== 'inline') && (options.prototypes !== 'module')) {
     tree.push("require('nativejsx/dist/nativejsx-prototypes.js');");
   }
-  tree.push(nativejsx.transpile(source, query));
+  tree.push(nativejsx.transpile(source, options));
 
   return tree.join('\n');
 };

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "author": "Trey Cordova",
   "license": "MIT",
   "dependencies": {
-    "nativejsx": "^4.0.0",
-    "loader-utils": "^0.2.12"
+    "loader-utils": "^2.0.0",
+    "nativejsx": "^4.0.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",


### PR DESCRIPTION
Removes the deprecation warning about parseQuery introduced by https://github.com/webpack/loader-utils/issues/56 and updates loader-utils.